### PR TITLE
fix: get proper parser name

### DIFF
--- a/lua/tabtree/init.lua
+++ b/lua/tabtree/init.lua
@@ -45,7 +45,12 @@ end
 
 function M.next()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local lang = vim.api.nvim_buf_get_option(bufnr, "filetype")
+	local ft = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  local lang = vim.treesitter.language.get_lang(ft)
+  if lang == nil then
+    error("no parsers found for ".. ft)
+    return
+  end
 	local target_query, offsets = get_language_config(lang)
 	local parser = vim.treesitter.get_parser(bufnr, lang)
 	local tree = parser:parse()[1]
@@ -64,7 +69,12 @@ end
 
 function M.previous()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local lang = vim.api.nvim_buf_get_option(bufnr, "filetype")
+	local ft = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  local lang = vim.treesitter.language.get_lang(ft)
+  if lang == nil then
+    error("no parsers found for ".. ft)
+    return
+  end
 	local target_query, offsets = get_language_config(lang)
 	local parser = vim.treesitter.get_parser(bufnr, lang)
 	local tree = parser:parse()[1]

--- a/lua/tabtree/init.lua
+++ b/lua/tabtree/init.lua
@@ -46,11 +46,13 @@ end
 function M.next()
 	local bufnr = vim.api.nvim_get_current_buf()
 	local ft = vim.api.nvim_buf_get_option(bufnr, "filetype")
-  local lang = vim.treesitter.language.get_lang(ft)
-  if lang == nil then
-    error("no parsers found for ".. ft)
-    return
-  end
+	local lang = vim.treesitter.language.get_lang(ft)
+	if lang == nil then
+		if config.options.debug then
+			error("no parsers found for " .. ft)
+		end
+		return
+	end
 	local target_query, offsets = get_language_config(lang)
 	local parser = vim.treesitter.get_parser(bufnr, lang)
 	local tree = parser:parse()[1]
@@ -70,11 +72,13 @@ end
 function M.previous()
 	local bufnr = vim.api.nvim_get_current_buf()
 	local ft = vim.api.nvim_buf_get_option(bufnr, "filetype")
-  local lang = vim.treesitter.language.get_lang(ft)
-  if lang == nil then
-    error("no parsers found for ".. ft)
-    return
-  end
+	local lang = vim.treesitter.language.get_lang(ft)
+	if lang == nil then
+		if config.options.debug then
+			error("no parsers found for " .. ft)
+		end
+		return
+	end
 	local target_query, offsets = get_language_config(lang)
 	local parser = vim.treesitter.get_parser(bufnr, lang)
 	local tree = parser:parse()[1]


### PR DESCRIPTION
filetype not always equal parser name. Gives error for me on `tsx` files because its filetype `typescriptreact`